### PR TITLE
Cleanup font rendering, fix incorrect colors, good performance boost

### DIFF
--- a/src/plugin/sdl/sdlcore.cpp
+++ b/src/plugin/sdl/sdlcore.cpp
@@ -600,15 +600,9 @@ void SDLCore::drawText(int nX, int nY, const char *sText, bool bBold, bool bItal
 		font = m_fontBold;
 	}
 
-	SDL_Surface* textSurface = TTF_RenderText_Blended(font, sText, m_foregroundColor);
+	SDL_Surface* textSurface = TTF_RenderText_Shaded(font, sText,
+																m_foregroundColor, m_backgroundColor);
 
-	drawRect(nX, nY, textSurface->w, textSurface->h, m_backgroundColor, 1.0f);
-
-	glColor4f(
-		((float)m_foregroundColor.r) / 255.0f,
-		((float)m_foregroundColor.g) / 255.0f,
-		((float)m_foregroundColor.b) / 255.0f,
-		1.0f);
 
 	if (textSurface == NULL)
 	{
@@ -616,7 +610,7 @@ void SDLCore::drawText(int nX, int nY, const char *sText, bool bBold, bool bItal
 		return;
 	}
 
-	SDL_SetAlpha(textSurface, 0, 0);
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 	drawSurface(nX, nY, textSurface);
 	SDL_FreeSurface(textSurface);
 

--- a/src/plugin/sdl/sdlterminal.cpp
+++ b/src/plugin/sdl/sdlterminal.cpp
@@ -558,11 +558,7 @@ void SDLTerminal::redraw()
 	{
 		int nY = m_surface->h - 32;
 
-		glColor4f(
-			((float)m_colors[TS_COLOR_WHITE_BRIGHT].r) / 255.0f,
-			((float)m_colors[TS_COLOR_WHITE_BRIGHT].g) / 255.0f,
-			((float)m_colors[TS_COLOR_WHITE_BRIGHT].b) / 255.0f,
-			0.70f);
+		glColor4f(1.0f, 1.0f, 1.0f, 0.70f);
 
 		if (m_keyMod == TERM_KEYMOD_CTRL)
 		{


### PR DESCRIPTION
See commits for details, let me know if you have any questions.

The color correctness thing was a surprising find, but it certainly makes a difference, as does the performance increase.

In my hacktastic performance benchmark 'time dmesg' goes from ~1.1s to ~0.9s, which if relevant is a nice improvement.
