### PR TITLE
New GL backend

### DIFF
--- a/src/plugin/Makefile
+++ b/src/plugin/Makefile
@@ -3,10 +3,10 @@ include ../../Makefile.inc
 CXXFLAGS	:=	$(MARCH_TUNE) -I. -I$(ROOT)/include -I$(ROOT)/include/SDL
 LDFLAGS		:=	-L$(ROOT)/lib -Wl,--allow-shlib-undefined -lpdl -lSDL -lSDL_ttf -lSDL_image -lGLES_CM -lpthread
 
-OBJECTS		:=	sdl/sdlcore.o sdl/sdlterminal.o \
+OBJECTS		:=	sdl/sdlfontgl.o sdl/sdlcore.o sdl/sdlterminal.o \
 				util/configmanager.o util/databuffer.o util/point.o \
 				terminal/seqparser.o terminal/terminal.o terminal/terminalconfigmanager.o \
-				terminal/terminalstate.o terminal/vtterminalstate.o terminalmain.o
+				terminal/terminalstate.o terminal/vtterminalstate.o terminalmain.o \
 
 wterm: $(OBJECTS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(OBJECTS) -o $@

--- a/src/plugin/sdl/sdlcore.cpp
+++ b/src/plugin/sdl/sdlcore.cpp
@@ -38,31 +38,8 @@ SDLCore::SDLCore()
 	m_surface = NULL;
 	m_nFontSize = 12;
 
-	SDL_Color m_colors[] = {
-			{ 0, 0, 0 }, // COLOR_BLACK
-			{ 187, 0, 0 }, // COLOR_RED
-			{ 0, 187, 0 }, // COLOR_GREEN
-			{ 187, 187, 0 }, // COLOR_YELLOW
-			{ 0, 0, 187 }, // COLOR_BLUE
-			{ 187, 0, 187 }, // COLOR_MAGENTA
-			{ 0, 187, 187 }, // COLOR_CYAN
-			{ 187, 187, 187 }, // COLOR_WHITE
-			{ 85, 85, 85 }, // COLOR_BLACK_BRIGHT
-			{ 255, 85, 85 }, // COLOR_RED_BRIGHT
-			{ 85, 255, 85 }, // COLOR_GREEN_BRIGHT
-			{ 255, 255, 85 }, // COLOR_YELLOW_BRIGHT
-			{ 85, 85, 255 }, // COLOR_BLUE_BRIGHT
-			{ 255, 85, 255 }, // COLOR_MAGENTA_BRIGHT
-			{ 85, 255, 255 }, // COLOR_CYAN_BRIGHT
-			{ 255, 255, 255 }, // COLOR_WHITE_BRIGHT
-			{ 187, 187, 187 }, // COLOR_FOREGROUND
-			{ 0, 0, 0 }, // COLOR_BACKGROUND
-			{ 255, 255, 255 }, // COLOR_FOREGROUND_BRIGHT
-			{ 0, 0, 0 }, // COLOR_BACKGROUND_BRIGHT
-	};
-
-	m_foregroundColor = m_colors[TS_COLOR_FOREGROUND];
-	m_backgroundColor = m_colors[TS_COLOR_BACKGROUND];
+	m_foregroundColor = TS_COLOR_FOREGROUND;
+	m_backgroundColor = TS_COLOR_BACKGROUND;
 
 	m_fontNormal = NULL;
 	m_fontBold = NULL;
@@ -505,10 +482,11 @@ void SDLCore::drawCursor(int nColumn, int nLine)
  */
 void SDLCore::clearScreen()
 {
+	SDL_Color bkgd = getColor(m_backgroundColor);
 	glClearColor(
-		((float)m_backgroundColor.r) / 255.0f,
-		((float)m_backgroundColor.g) / 255.0f,
-		((float)m_backgroundColor.b) / 255.0f,
+		((float)bkgd.r) / 255.0f,
+		((float)bkgd.g) / 255.0f,
+		((float)bkgd.b) / 255.0f,
 		1.0f);
 
 	glClear(GL_COLOR_BUFFER_BIT);
@@ -631,7 +609,8 @@ void SDLCore::drawText(int nX, int nY, const char *sText, bool bBold, bool bItal
 		font = m_fontBold;
 	}
 
-	SDL_Surface* textSurface = TTF_RenderText_Shaded(font, sText, m_foregroundColor, m_backgroundColor);
+	SDL_Surface* textSurface = TTF_RenderText_Shaded(font, sText, getColor(m_foregroundColor), getColor(m_backgroundColor));
+
 
 	if (textSurface == NULL)
 	{
@@ -644,24 +623,6 @@ void SDLCore::drawText(int nX, int nY, const char *sText, bool bBold, bool bItal
 	SDL_FreeSurface(textSurface);
 
 	setDirty(BUFFER_DIRTY_BIT);
-}
-
-void SDLCore::setForegroundColor(unsigned char nRed, unsigned char nGreen, unsigned char nBlue)
-{
-	m_foregroundColor.r = nRed;
-	m_foregroundColor.g = nGreen;
-	m_foregroundColor.b = nBlue;
-
-	setDirty(FOREGROUND_COLOR_DIRTY_BIT);
-}
-
-void SDLCore::setBackgroundColor(unsigned char nRed, unsigned char nGreen, unsigned char nBlue)
-{
-	m_backgroundColor.r = nRed;
-	m_backgroundColor.g = nGreen;
-	m_backgroundColor.b = nBlue;
-
-	setDirty(BACKGROUND_COLOR_DIRTY_BIT);
 }
 
 /**

--- a/src/plugin/sdl/sdlcore.hpp
+++ b/src/plugin/sdl/sdlcore.hpp
@@ -25,11 +25,12 @@
 #include <map>
 
 #include "terminal/vtterminalstate.hpp"
+#include "sdlfontgl.h"
 
 /**
  * Initializer and basic 2D function for webOS SDL.
  */
-class SDLCore
+class SDLCore : protected SDLFontGL
 {
 protected:
 	static const int BUFFER_DIRTY_BIT;
@@ -81,6 +82,7 @@ private:
 	void eventLoop();
 
 	void closeFonts();
+	void resetGlyphCache();
 
 public:
 	SDLCore();

--- a/src/plugin/sdl/sdlcore.hpp
+++ b/src/plugin/sdl/sdlcore.hpp
@@ -38,8 +38,8 @@ protected:
 	static const int BACKGROUND_COLOR_DIRTY_BIT;
 
 	SDL_Surface *m_surface;
-	SDL_Color m_backgroundColor;
-	SDL_Color m_foregroundColor;
+	TSColor_t m_foregroundColor;
+	TSColor_t m_backgroundColor;
 
 	int createFonts(int nSize);
 

--- a/src/plugin/sdl/sdlfontgl.cpp
+++ b/src/plugin/sdl/sdlfontgl.cpp
@@ -1,0 +1,415 @@
+/**
+ * This file is part of SDLTerminal.
+ * Copyright (C) 2012 Will Dietz <webos@wdtz.org>
+ *
+ * SDLTerminal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SDLTerminal is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with SDLTerminal.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "sdl/sdlfontgl.h"
+
+#include <syslog.h>
+
+// Log assertion failures to syslog
+#define assert(c) \
+	do { \
+		if (!(c)) \
+			syslog(LOG_ERR, "Assertion \"%s\" failed at %s:%d", \
+					__STRING(c), __FILE__, __LINE__); \
+	} while(0)
+
+// For debugging
+#define checkGLError() \
+	do { \
+		int err = glGetError(); \
+		if (err) syslog(LOG_ERR, "GL Error %x at %s:%d", \
+				err, __FILE__, __LINE__); \
+	} while(0)
+
+// Helper functions
+static void getRGBAMask(Uint32 &rmask, Uint32 &gmask,
+												Uint32 &bmask, Uint32 &amask) {
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+		rmask = 0xff000000;
+		gmask = 0x00ff0000;
+		bmask = 0x0000ff00;
+		amask = 0x000000ff;
+#else
+		rmask = 0x000000ff;
+		gmask = 0x0000ff00;
+		bmask = 0x00ff0000;
+		amask = 0xff000000;
+#endif
+}
+
+static int getGLFormat() {
+	SDL_Surface *s = SDL_GetVideoSurface();
+	if (s->format->BytesPerPixel == 3)
+		return GL_RGB;
+	if (s->format->BytesPerPixel == 4)
+		return GL_RGBA;
+	assert(0 && "Unsupported bpp");
+	return -1;
+}
+
+static unsigned nextPowerOfTwo(int n) {
+	assert(n > 0);
+
+	unsigned res = 1;
+	while (res < (unsigned)n) res <<= 1;
+
+	return res;
+}
+
+void SDLFontGL::setupFontGL(int fnCount, TTF_Font** fnts, int colCount, SDL_Color *cols) {
+	clearGL();
+
+	assert(fnts && cols);
+	assert((fnCount > 0) && (colCount > 0));
+
+	nFonts = fnCount;
+	nCols = colCount;
+
+	this->fnts = (TTF_Font**)malloc(nFonts*sizeof(TTF_Font*));
+	memcpy(this->fnts, fnts, nFonts*sizeof(TTF_Font*));
+
+	this->cols = (SDL_Color*)malloc(nCols*sizeof(SDL_Color));
+	memcpy(this->cols, cols, nCols*sizeof(SDL_Color));
+
+	GlyphCache = 0;
+
+	haveFontLine = (bool*)malloc(nFonts*sizeof(bool));
+	memset(haveFontLine, 0, nFonts*sizeof(bool));
+
+	if (TTF_SizeText(fnts[0], "O", &nWidth, &nHeight) != 0)
+		assert(0 && "Failed to size font");
+	assert((nWidth > 0) && (nHeight > 0));
+}
+
+void SDLFontGL::createTexture() {
+	// Create Big GL texture:
+	glGenTextures(1,&GlyphCache);
+	glBindTexture(GL_TEXTURE_2D, GlyphCache);
+
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+	// Set size of the texture, but no data.
+	// We want 1 extra row of pixel data
+	// so we can draw solid colors as part
+	// of the same operations.
+	texW = nextPowerOfTwo(nChars*nWidth);
+	texH = nextPowerOfTwo(nFonts*nHeight + 1);
+	int nMode = getGLFormat();
+	glTexImage2D(GL_TEXTURE_2D,
+			0, nMode,
+			texW, texH,
+			0, nMode,
+			GL_UNSIGNED_BYTE, NULL);
+
+
+	// Put a single white pixel at bottom of texture.
+	// We use this as the 'texture' data for blitting
+	// solid backgrounds.
+	char whitepixel[] = { 255, 255, 255, 255 };
+	assert(nFonts && nHeight);
+	glTexSubImage2D(GL_TEXTURE_2D, 0,
+			0,nFonts*nHeight,
+			1, 1,
+			GL_RGBA, GL_UNSIGNED_BYTE, whitepixel);
+	checkGLError();
+}
+
+SDLFontGL::~SDLFontGL() {
+	clearGL();
+}
+
+void SDLFontGL::clearGL() {
+	if (GlyphCache) {
+		glDeleteTextures(1, &GlyphCache);
+		GlyphCache = 0;
+	}
+
+	free(haveFontLine);
+	free(fnts);
+	free(cols);
+	free(colorValues);
+	free(texValues);
+	free(vtxValues);
+
+	haveFontLine = 0;
+	fnts = NULL;
+	cols = NULL;
+	colorValues = NULL;
+	texValues = NULL;
+	vtxValues = NULL;
+
+	nFonts = nCols = 0;
+	screenRows = screenCols = 0;
+	numChars = 0;
+}
+
+void SDLFontGL::ensureFontLine(int fnt)
+{
+
+	assert(fnt >= 0 && fnt < nFonts);
+	assert(fnts && cols && GlyphCache && haveFontLine);
+
+	bool & have = haveFontLine[fnt];
+	if (have) {
+		return;
+	}
+	have = true;
+
+	// Lookup requested font
+	TTF_Font * font = fnts[fnt];
+	assert(font);
+
+	// Grab the native video surface (so we can match its bpp)
+	SDL_Surface* videoSurface = SDL_GetVideoSurface();
+	assert(videoSurface);
+	assert(videoSurface->format->BitsPerPixel == 32);
+
+	// Create a surface for all the characters
+	Uint32 rmask, gmask, bmask, amask;
+	getRGBAMask(rmask, gmask, bmask, amask);
+	SDL_Surface* mainSurface =
+		SDL_CreateRGBSurface(SDL_SWSURFACE,
+				nChars*nWidth, nHeight,
+				videoSurface->format->BitsPerPixel,
+				rmask, gmask, bmask, amask);
+	assert(mainSurface);
+
+	// Render font in white, will colorize on-the-fly
+	SDL_Color fg = { 255, 255, 255 };
+
+	// Set texture to entirely clear
+	// TODO: Needed?
+	Uint32 fillColor = SDL_MapRGBA(mainSurface->format, 0, 0, 0, SDL_ALPHA_TRANSPARENT);
+	SDL_FillRect(mainSurface, NULL, fillColor);
+
+	// For each character, render the glyph, and put in the appropriate location
+	for(int i = 0; i < nChars; ++i)
+	{
+		// Make a little string out of the character
+		char buf[2] = { printableChars[i], 0 };
+
+		SDL_Surface* surface = TTF_RenderText_Blended(font, (const char*)buf, fg);
+		SDL_SetAlpha(surface, 0, 0);
+
+		SDL_Rect dstRect = { 0, 0, nWidth, nHeight };
+		dstRect.x = i*nWidth;
+
+		SDL_BlitSurface(surface, 0, mainSurface, &dstRect);
+
+		SDL_FreeSurface(surface);
+	}
+
+	// Now upload the big set of characters as a single texture:
+	{
+		int nMode = getGLFormat();
+
+		glBindTexture(GL_TEXTURE_2D, GlyphCache);
+
+		// Upload this font to its place in the big texture
+		glTexSubImage2D(GL_TEXTURE_2D, 0,
+				0, fnt*nHeight,
+				mainSurface->w, mainSurface->h,
+				nMode, GL_UNSIGNED_BYTE, mainSurface->pixels);
+		glFlush();
+	}
+
+	SDL_FreeSurface(mainSurface);
+}
+
+void SDLFontGL::drawBackground(int color, int nX, int nY, int cells) {
+	// Blit a rectangle of the specified color at the specified coordinates
+	// (Err, don't blit, but insert into our arrays the equivalent)
+	const int stride = 12;
+	GLfloat *tex = &texValues[stride*numChars];
+	GLfloat *vtx = &vtxValues[stride*numChars];
+	GLfloat *clrs = &colorValues[2*stride*numChars];
+	++numChars;
+
+	GLfloat vtxCopy[] = {
+		nX, nY,
+		nX, nY + nHeight,
+		nX + cells*nWidth, nY,
+		nX, nY + nHeight,
+		nX + cells*nWidth, nY,
+		nX + cells*nWidth, nY + nHeight
+	};
+	memcpy(vtx, vtxCopy, sizeof(vtxCopy));
+
+	float y_offset = ((float)nFonts*nHeight)/(float)texH;
+	float x1 = ((float)1)/(float)texW;
+	float y1 = ((float)1)/(float)texH;
+	GLfloat texCopy[] = {
+		0.0, y_offset,
+		0.0, y_offset + y1,
+		x1,  y_offset,
+		0.0, y_offset + y1,
+		x1,  y_offset,
+		x1,  y_offset + y1
+	};
+	memcpy(tex, texCopy, sizeof(texCopy));
+
+	// Duplicate color...
+	SDL_Color bgc = cols[color];
+	GLfloat colorCopy[] = {
+			((float)bgc.r)/255.f,
+			((float)bgc.g)/255.f,
+			((float)bgc.b)/255.f,
+			1.f,
+	};
+
+	for(unsigned i = 0; i < 6; ++i) {
+		memcpy(&clrs[i*4], colorCopy, sizeof(colorCopy));
+	}
+}
+
+void SDLFontGL::drawTextGL(int fnt, int fg, int bg,
+													 int nX, int nY, const char * text) {
+	if (!GlyphCache) createTexture();
+
+	assert(fnt >= 0 && fnt < nFonts);
+	assert(fg >= 0 && fg < nCols);
+	assert(bg >= 0 && bg < nCols);
+	assert(fnts && cols && GlyphCache);
+
+	unsigned len = strlen(text);
+
+	// Ensure we have this font line:
+	ensureFontLine(fnt);
+
+	const int stride = 12; // GL_TRIANGLE_STRIP 2*6
+
+	drawBackground(bg, nX, nY, len);
+
+	GLfloat *tex = &texValues[stride*numChars];
+	GLfloat *vtx = &vtxValues[stride*numChars];
+	GLfloat *clrs = &colorValues[2*stride*numChars];
+	numChars += len;
+
+	float x_scale = ((float)nWidth) / (float)texW;
+	float y_scale = ((float)nHeight) / (float)texH;
+	GLfloat texCopy[] = {
+		0.0, 0.0,
+		0.0, y_scale,
+		x_scale, 0.0,
+		0.0, y_scale,
+		x_scale, 0.0,
+		x_scale, y_scale
+	};
+	GLfloat vtxCopy[] = {
+		nX, nY,
+		nX, nY + nHeight,
+		nX + nWidth, nY,
+		nX, nY + nHeight,
+		nX + nWidth, nY,
+		nX + nWidth, nY + nHeight
+	};
+	SDL_Color fgc = cols[fg];
+	GLfloat colorCopy[] = {
+			((float)fgc.r)/255.f,
+			((float)fgc.g)/255.f,
+			((float)fgc.b)/255.f,
+			1.f,
+			((float)fgc.r)/255.f,
+			((float)fgc.g)/255.f,
+			((float)fgc.b)/255.f,
+			1.f,
+			((float)fgc.r)/255.f,
+			((float)fgc.g)/255.f,
+			((float)fgc.b)/255.f,
+			1.f,
+			((float)fgc.r)/255.f,
+			((float)fgc.g)/255.f,
+			((float)fgc.b)/255.f,
+			1.f,
+			((float)fgc.r)/255.f,
+			((float)fgc.g)/255.f,
+			((float)fgc.b)/255.f,
+			1.f,
+			((float)fgc.r)/255.f,
+			((float)fgc.g)/255.f,
+			((float)fgc.b)/255.f,
+			1.f
+	};
+
+	float y_offset = ((float)(fnt*nHeight)) / (float)texH;
+	for (unsigned i = 0; i < len; ++i)
+	{
+		// Populate texture coordinates
+		memcpy(&tex[i*stride],texCopy,sizeof(texCopy));
+
+		char c = text[i];
+
+		int index = c > 127 ? c - 33 : c - 32;
+		float x_offset = ((float)(index * nWidth)) / texW;
+
+		for(unsigned j = 0; j < stride; j += 2) {
+			tex[i*stride+j] += x_offset;
+			tex[i*stride+j+1] += y_offset;
+		}
+
+		// Populate vertex coordinates
+		memcpy(&vtx[i*stride],vtxCopy,sizeof(vtxCopy));
+		for(unsigned j = 0; j < stride; j += 2) {
+			vtxCopy[j] += nWidth;
+		}
+
+		// Populate color coodinates
+		memcpy(&clrs[i*2*stride], colorCopy, sizeof(colorCopy));
+	}
+}
+
+void SDLFontGL::startTextGL(int rows, int cols) {
+	// If this is a new screen dimension, reset our data:
+	if (rows != screenRows || cols != screenCols) {
+		free(colorValues);
+		free(texValues);
+		free(vtxValues);
+
+		screenRows = rows;
+		screenCols = cols;
+
+		// (at most) 2 operations per cell: background, foreground text
+		int nCells = screenRows * screenCols * 2;
+		colorValues = (GLfloat*)malloc(nCells*sizeof(GLfloat)*24);
+		texValues = (GLfloat*)malloc(nCells*sizeof(GLfloat)*12);
+		vtxValues = (GLfloat*)malloc(nCells*sizeof(GLfloat)*12);
+
+	}
+
+	// Start over
+	numChars = 0;
+}
+
+void SDLFontGL::endTextGL() {
+	// We've built up commands for the entire screen!
+	// Tell GL where all the information is, and render!
+
+	// Bind the master font texture
+	glBindTexture(GL_TEXTURE_2D, GlyphCache);
+	glEnableClientState(GL_COLOR_ARRAY);
+
+	// Point GL to our arrays...
+	glColorPointer(4, GL_FLOAT, 0, colorValues);
+	glTexCoordPointer(2, GL_FLOAT, 0, texValues);
+	glVertexPointer(2, GL_FLOAT, 0, vtxValues);
+	// Go!
+	glDrawArrays(GL_TRIANGLES, 0, 6*numChars);
+	glFlush();
+	glDisableClientState(GL_COLOR_ARRAY);
+}

--- a/src/plugin/sdl/sdlfontgl.h
+++ b/src/plugin/sdl/sdlfontgl.h
@@ -1,0 +1,79 @@
+/**
+ * This file is part of SDLTerminal.
+ * Copyright (C) 2012 Will Dietz <webos@wdtz.org>
+ *
+ * SDLTerminal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SDLTerminal is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with SDLTerminal.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _SDLFONTGL_H_
+#define _SDLFONTGL_H_
+
+#include <GLES/gl.h>
+#include <SDL/SDL.h>
+#include <SDL/SDL_ttf.h>
+
+// OpenGL Font Rendering
+class SDLFontGL {
+private:
+	// Master font rendering texture.
+	GLuint GlyphCache;
+	int texW, texH;
+
+	// Dirty bit for each font
+	bool * haveFontLine;
+
+	int nFonts, nCols;
+	TTF_Font** fnts;
+	SDL_Color* cols;
+	int nWidth, nHeight;
+
+	int screenCols, screenRows;
+	GLfloat * colorValues;
+	GLfloat * texValues;
+	GLfloat * vtxValues;
+	int numChars;
+	char printableChars[223];
+	size_t nChars;
+
+	void clearGL();
+	void ensureFontLine(int font);
+	void createTexture();
+	void drawBackground(int color, int X, int Y, int cells);
+
+public:
+	SDLFontGL() : GlyphCache(0), texW(0), texH(0),
+	nFonts(0), nCols(0), fnts(0), cols(0), screenCols(0), screenRows(0),
+	colorValues(0), texValues(0), vtxValues(0) {
+		// Characters [32,127),[128,255]
+		for(unsigned i = 32; i < 127; ++i)
+			printableChars[i-32] = i;
+		for(unsigned i = 128; i < 256; ++i)
+			printableChars[i-33] = i;
+		printableChars[223] = '\0';
+		nChars = 223;
+	}
+	~SDLFontGL();
+
+	// Indicate what fonts and colors to use
+	// This invalidates the cache, so only call when things change.
+	void setupFontGL(int fnCount, TTF_Font** fnts, int colCount, SDL_Color *cols);
+
+	// Begin drawing text to the screen, assuming the given screen size
+	void startTextGL(int cols, int rows);
+	void drawTextGL(int font, int fg, int bg, int x, int y, const char * text);
+	// Done drawing text, commit!
+	void endTextGL();
+};
+
+#endif // _SDLFONTGL_H_

--- a/src/plugin/sdl/sdlterminal.cpp
+++ b/src/plugin/sdl/sdlterminal.cpp
@@ -448,6 +448,9 @@ void SDLTerminal::redraw()
 	setGraphicsState(defState);
 	clearScreen();
 
+	startTextGL(m_terminalState->getDisplayScreenSize().getX() + 1,
+							m_terminalState->getDisplayScreenSize().getY() + 1);
+
 	if (size <= 0)
 	{
 		nResult = -1;
@@ -552,6 +555,8 @@ void SDLTerminal::redraw()
 		free(states);
 	}
 
+	endTextGL();
+
 	m_terminalState->unlock();
 
 	if (m_keyMod != TERM_KEYMOD_NONE)
@@ -653,16 +658,19 @@ void SDLTerminal::setColor(TSColor_t color, int r, int g, int b)
 	m_colors[color].r = r;
 	m_colors[color].g = g;
 	m_colors[color].b = b;
+	setDirty(FONT_DIRTY_BIT);
 }
 
 void SDLTerminal::setForegroundColor(TSColor_t color)
 {
 	m_foregroundColor = color;
+	setDirty(FOREGROUND_COLOR_DIRTY_BIT);
 }
 
 void SDLTerminal::setBackgroundColor(TSColor_t color)
 {
 	m_backgroundColor = color;
+	setDirty(BACKGROUND_COLOR_DIRTY_BIT);
 }
 
 void SDLTerminal::setGraphicsState(TSLineGraphicsState_t &state)

--- a/src/plugin/sdl/sdlterminal.cpp
+++ b/src/plugin/sdl/sdlterminal.cpp
@@ -657,12 +657,12 @@ void SDLTerminal::setColor(TSColor_t color, int r, int g, int b)
 
 void SDLTerminal::setForegroundColor(TSColor_t color)
 {
-	m_foregroundColor = getColor(color);
+	m_foregroundColor = color;
 }
 
 void SDLTerminal::setBackgroundColor(TSColor_t color)
 {
-	m_backgroundColor = getColor(color);
+	m_backgroundColor = color;
 }
 
 void SDLTerminal::setGraphicsState(TSLineGraphicsState_t &state)

--- a/src/plugin/terminalmain.cpp
+++ b/src/plugin/terminalmain.cpp
@@ -93,13 +93,13 @@ int main(int argc, const char* argv[])
 
 	openlog("us.ryanhope.wterm.plugin", LOG_PID, LOG_USER);
 
+	PDL_Init(0);
+
 	sdlTerminal = new SDLTerminal();
 	Terminal *terminal = new Terminal();
 
 	sdlTerminal->start();
 	sdlTerminal->setFontSize(atoi(argv[1]));
-
-	PDL_Init(0);
 
 	PDL_RegisterJSHandler("setColor", setColor);
 	PDL_RegisterJSHandler("pushKeyEvent", pushKeyEvent);


### PR DESCRIPTION
See commits for details, this is very much faster.

One way to see it in action is to try the following:

Time the execution of the following script: https://gist.github.com/1577147
(Taken from http://tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html, modified to loop 1000x)

Existing wterm: 1m 7.65s
After this patch: 22.78s

Note that I believe the actual rendering speedup is significantly more than that (we _greatly_ reduce cost of rendering), but I don't have a useful way to benchmark it at the moment.
