### PR TITLE
Fix CS_ECH by erasing characters to blanks instead of null-terminators.

### DIFF
--- a/src/plugin/terminal/terminalstate.cpp
+++ b/src/plugin/terminal/terminalstate.cpp
@@ -172,7 +172,7 @@ void TerminalState::clearBufferLine(int nLine, int nStart, int nEnd)
 		if (nStart <= nEnd)
 		{
 			nSize = (nEnd - nStart + 1);
-			line->clear(nStart, nSize, false);
+			line->clear(nStart, nSize, false, ' ');
 		}
 	}
 

--- a/src/plugin/terminal/vtterminalstate.cpp
+++ b/src/plugin/terminal/vtterminalstate.cpp
@@ -62,7 +62,7 @@ bool VTTerminalState::processNonPrintableChar(char &c)
 
 void VTTerminalState::processControlSeq(int nToken, int *values, int numValues, ExtTerminal *extTerminal)
 {
-	int i;
+	int i, len;
 
 	pthread_mutex_lock(&m_rwLock);
 
@@ -74,8 +74,9 @@ void VTTerminalState::processControlSeq(int nToken, int *values, int numValues, 
 	case CS_VPA: //ESC[<Line>d
 		setCursorLocation(m_cursorLoc.getX(), values[0]);
 		break;
-	case CS_ECH: //ESC[<Line>X
-		erase(Point(m_cursorLoc.getX(), m_cursorLoc.getY()), Point(m_cursorLoc.getX()+values[0], m_cursorLoc.getY()));
+	case CS_ECH: //ESC[<Chars>X
+		len = values[0] ? values[0] - 1 : 0;
+		erase(m_cursorLoc, Point(m_cursorLoc.getX()+len, m_cursorLoc.getY()));
 		break;
 	case CS_IL: //ESC[<Lines>L
 		insertLines(values[0] ? values[0] : 1);

--- a/src/plugin/util/databuffer.cpp
+++ b/src/plugin/util/databuffer.cpp
@@ -258,8 +258,10 @@ int DataBuffer::copy(char *dest, size_t size)
  * The size of the buffer is decreased if data is shifted, or the tail of the buffer is removed.
  * Returns -1 if an error occurs. Returns 0 if success.
  */
-int DataBuffer::clear(int startIndex, size_t size, bool bShift)
+int DataBuffer::clear(int startIndex, size_t size, bool bShift, char clearChar)
 {
+	// clearChar is used when not bShift
+
 	int nResult = 0;
 
 	pthread_mutex_lock(&m_rwLock);
@@ -295,7 +297,7 @@ int DataBuffer::clear(int startIndex, size_t size, bool bShift)
 		}
 		else
 		{
-			memset(m_buffer + startIndex, 0, size);
+			memset(m_buffer + startIndex, clearChar, size);
 
 			if ((startIndex + size) >= m_size)
 			{

--- a/src/plugin/util/databuffer.hpp
+++ b/src/plugin/util/databuffer.hpp
@@ -46,7 +46,7 @@ public:
 	int copy(char *dest, size_t size);
 	int copy(int startIndex, char *dest, size_t size);
 	int insert(int startIndex, const char *data, size_t size);
-	int clear(int startIndex, size_t size, bool bShift);
+	int clear(int startIndex, size_t size, bool bShift, char clearChar='\0');
 	int clear();
 	size_t size() const;
 	void print(FILE *out);


### PR DESCRIPTION
Fixes issue #23.

This is needed because dataBuffer treats data as random array of bytes and needs
to be told that it should clear to a string-friendly value like blank :).
(Various locations assume lines have string-like properties)
