### PR TITLE
Undo null/blank changes in databuffer, instead stringify before render.

### DIFF
--- a/src/plugin/sdl/sdlterminal.cpp
+++ b/src/plugin/sdl/sdlterminal.cpp
@@ -28,6 +28,13 @@
 #include <time.h>
 #include <syslog.h>
 
+// Convert mid-string null characters to blanks
+static void stringify(char * str, size_t len) {
+	for(unsigned i = 0; i < len; ++i)
+		if (!str[i]) str[i] = ' ';
+	str[len] = '\0';
+}
+
 SDLTerminal::SDLTerminal()
 {
 	m_terminalState = NULL;
@@ -481,6 +488,7 @@ void SDLTerminal::redraw()
 			databuffer = m_terminalState->getBufferLine(i);
 			memset(sBuffer, 0, size);
 			databuffer->copy(sBuffer, size - 1);
+			stringify(sBuffer, databuffer->size());
 
 			if (nNumStates > 0)
 			{

--- a/src/plugin/terminal/terminalstate.cpp
+++ b/src/plugin/terminal/terminalstate.cpp
@@ -172,7 +172,7 @@ void TerminalState::clearBufferLine(int nLine, int nStart, int nEnd)
 		if (nStart <= nEnd)
 		{
 			nSize = (nEnd - nStart + 1);
-			line->clear(nStart, nSize, false, ' ');
+			line->clear(nStart, nSize, false);
 		}
 	}
 

--- a/src/plugin/util/databuffer.cpp
+++ b/src/plugin/util/databuffer.cpp
@@ -258,10 +258,8 @@ int DataBuffer::copy(char *dest, size_t size)
  * The size of the buffer is decreased if data is shifted, or the tail of the buffer is removed.
  * Returns -1 if an error occurs. Returns 0 if success.
  */
-int DataBuffer::clear(int startIndex, size_t size, bool bShift, char clearChar)
+int DataBuffer::clear(int startIndex, size_t size, bool bShift)
 {
-	// clearChar is used when not bShift
-
 	int nResult = 0;
 
 	pthread_mutex_lock(&m_rwLock);
@@ -297,7 +295,7 @@ int DataBuffer::clear(int startIndex, size_t size, bool bShift, char clearChar)
 		}
 		else
 		{
-			memset(m_buffer + startIndex, clearChar, size);
+			memset(m_buffer + startIndex, 0, size);
 
 			if ((startIndex + size) >= m_size)
 			{

--- a/src/plugin/util/databuffer.hpp
+++ b/src/plugin/util/databuffer.hpp
@@ -46,7 +46,7 @@ public:
 	int copy(char *dest, size_t size);
 	int copy(int startIndex, char *dest, size_t size);
 	int insert(int startIndex, const char *data, size_t size);
-	int clear(int startIndex, size_t size, bool bShift, char clearChar='\0');
+	int clear(int startIndex, size_t size, bool bShift);
 	int clear();
 	size_t size() const;
 	void print(FILE *out);


### PR DESCRIPTION
Sorry for the churn on this, but pushing the stringification into the databuffer data structure was probably the wrong choice.

No functionality change intended.
