### PR TITLE
Extended mapping

### DIFF
--- a/src/plugin/sdl/sdlcore.cpp
+++ b/src/plugin/sdl/sdlcore.cpp
@@ -42,6 +42,8 @@ SDLCore::SDLCore()
 	m_backgroundColor = TS_COLOR_BACKGROUND;
 	m_bBold = false;
 	m_bUnderline = false;
+	m_slot1 = TS_CS_NONE;
+	m_slot2 = TS_CS_NONE;
 
 	m_fontNormal = NULL;
 	m_fontBold = NULL;
@@ -614,10 +616,8 @@ void SDLCore::drawText(int nX, int nY, const char *sText)
 	graphicsInfo.fg = (int)m_foregroundColor;
 	graphicsInfo.bg = (int)m_backgroundColor;
 
-	// TODO: Implement these!
-	// (Only refer here to slots we've told sdlfontgl about via setCharMapping)
-	graphicsInfo.slot1 = 0;
-	graphicsInfo.slot2 = 0;
+	graphicsInfo.slot1 = (int)m_slot1;
+	graphicsInfo.slot2 = (int)m_slot2;
 
 	drawTextGL(graphicsInfo, nX, nY, sText);
 

--- a/src/plugin/sdl/sdlcore.cpp
+++ b/src/plugin/sdl/sdlcore.cpp
@@ -609,7 +609,17 @@ void SDLCore::drawText(int nX, int nY, const char *sText)
 	else if (m_bBold)
 		fnt = 3;
 
-	drawTextGL(fnt, (int)m_foregroundColor, (int)m_backgroundColor, nX, nY, sText);
+	SDLFontGL::TextGraphicsInfo_t graphicsInfo;
+	graphicsInfo.font = fnt;
+	graphicsInfo.fg = (int)m_foregroundColor;
+	graphicsInfo.bg = (int)m_backgroundColor;
+
+	// TODO: Implement these!
+	// (Only refer here to slots we've told sdlfontgl about via setCharMapping)
+	graphicsInfo.slot1 = 0;
+	graphicsInfo.slot2 = 0;
+
+	drawTextGL(graphicsInfo, nX, nY, sText);
 
 	setDirty(BUFFER_DIRTY_BIT);
 }

--- a/src/plugin/sdl/sdlcore.hpp
+++ b/src/plugin/sdl/sdlcore.hpp
@@ -41,6 +41,8 @@ protected:
 	SDL_Surface *m_surface;
 	TSColor_t m_foregroundColor;
 	TSColor_t m_backgroundColor;
+	TSCharset_t m_slot1;
+	TSCharset_t m_slot2;
 	bool m_bBold;
 	bool m_bUnderline;
 

--- a/src/plugin/sdl/sdlfontgl.cpp
+++ b/src/plugin/sdl/sdlfontgl.cpp
@@ -36,6 +36,9 @@
 				err, __FILE__, __LINE__); \
 	} while(0)
 
+// How many characters do we support?
+static const int nChars = 128;
+
 // Helper functions
 static void getRGBAMask(Uint32 &rmask, Uint32 &gmask,
 												Uint32 &bmask, Uint32 &amask) {
@@ -88,10 +91,11 @@ void SDLFontGL::setupFontGL(int fnCount, TTF_Font** fnts, int colCount, SDL_Colo
 
 	GlyphCache = 0;
 
-	haveFontLine = (bool*)malloc(nFonts*sizeof(bool));
-	memset(haveFontLine, 0, nFonts*sizeof(bool));
+	haveCacheLine = (bool*)malloc(nFonts*MAX_CHARSETS*sizeof(bool));
+	memset(haveCacheLine, 0, nFonts*MAX_CHARSETS*sizeof(bool));
 
-	if (TTF_SizeText(fnts[0], "O", &nWidth, &nHeight) != 0)
+	const Uint16 OStr[] = {'O', 0};
+	if (TTF_SizeUNICODE(fnts[0], OStr, &nWidth, &nHeight) != 0)
 		assert(0 && "Failed to size font");
 	assert((nWidth > 0) && (nHeight > 0));
 }
@@ -109,13 +113,14 @@ void SDLFontGL::createTexture() {
 	// so we can draw solid colors as part
 	// of the same operations.
 	texW = nextPowerOfTwo(nChars*nWidth);
-	texH = nextPowerOfTwo(nFonts*nHeight + 1);
+	texH = nextPowerOfTwo(nFonts*MAX_CHARSETS*nHeight + 1);
 	int nMode = getGLFormat();
 	glTexImage2D(GL_TEXTURE_2D,
 			0, nMode,
 			texW, texH,
 			0, nMode,
 			GL_UNSIGNED_BYTE, NULL);
+	checkGLError();
 
 
 	// Put a single white pixel at bottom of texture.
@@ -124,7 +129,7 @@ void SDLFontGL::createTexture() {
 	char whitepixel[] = { 255, 255, 255, 255 };
 	assert(nFonts && nHeight);
 	glTexSubImage2D(GL_TEXTURE_2D, 0,
-			0,nFonts*nHeight,
+			0,nFonts*MAX_CHARSETS*nHeight,
 			1, 1,
 			GL_RGBA, GL_UNSIGNED_BYTE, whitepixel);
 	checkGLError();
@@ -140,14 +145,16 @@ void SDLFontGL::clearGL() {
 		GlyphCache = 0;
 	}
 
-	free(haveFontLine);
+	memset(charMappings, 0, sizeof(charMappings));
+
+	free(haveCacheLine);
 	free(fnts);
 	free(cols);
 	free(colorValues);
 	free(texValues);
 	free(vtxValues);
 
-	haveFontLine = 0;
+	haveCacheLine = 0;
 	fnts = NULL;
 	cols = NULL;
 	colorValues = NULL;
@@ -159,13 +166,14 @@ void SDLFontGL::clearGL() {
 	numChars = 0;
 }
 
-void SDLFontGL::ensureFontLine(int fnt)
+void SDLFontGL::ensureCacheLine(int fnt, int slot)
 {
 
 	assert(fnt >= 0 && fnt < nFonts);
-	assert(fnts && cols && GlyphCache && haveFontLine);
+	assert(slot >= 0 && slot < MAX_CHARSETS);
+	assert(fnts && cols && GlyphCache && haveCacheLine);
 
-	bool & have = haveFontLine[fnt];
+	bool & have = hasCacheLine(fnt, slot);
 	if (have) {
 		return;
 	}
@@ -201,18 +209,23 @@ void SDLFontGL::ensureFontLine(int fnt)
 	// For each character, render the glyph, and put in the appropriate location
 	for(int i = 0; i < nChars; ++i)
 	{
-		// Make a little string out of the character
-		char buf[2] = { printableChars[i], 0 };
+		// Lookup this character, and make a single-char string out of it.
+		Uint16 C = charMappings[slot].map[i];
+		if (!C) C = (Uint16)i;
+		Uint16 buf[2] = { C, 0 };
 
-		SDL_Surface* surface = TTF_RenderText_Blended(font, (const char*)buf, fg);
-		SDL_SetAlpha(surface, 0, 0);
+		SDL_Surface* surface = TTF_RenderUNICODE_Blended(font, (const Uint16*)buf, fg);
+		if (surface)
+		{
+			SDL_SetAlpha(surface, 0, 0);
 
-		SDL_Rect dstRect = { 0, 0, nWidth, nHeight };
-		dstRect.x = i*nWidth;
+			SDL_Rect dstRect = { 0, 0, nWidth, nHeight };
+			dstRect.x = i*nWidth;
 
-		SDL_BlitSurface(surface, 0, mainSurface, &dstRect);
+			SDL_BlitSurface(surface, 0, mainSurface, &dstRect);
 
-		SDL_FreeSurface(surface);
+			SDL_FreeSurface(surface);
+		}
 	}
 
 	// Now upload the big set of characters as a single texture:
@@ -223,7 +236,7 @@ void SDLFontGL::ensureFontLine(int fnt)
 
 		// Upload this font to its place in the big texture
 		glTexSubImage2D(GL_TEXTURE_2D, 0,
-				0, fnt*nHeight,
+				0, (slot*nFonts + fnt)*nHeight,
 				mainSurface->w, mainSurface->h,
 				nMode, GL_UNSIGNED_BYTE, mainSurface->pixels);
 		glFlush();
@@ -251,7 +264,7 @@ void SDLFontGL::drawBackground(int color, int nX, int nY, int cells) {
 	};
 	memcpy(vtx, vtxCopy, sizeof(vtxCopy));
 
-	float y_offset = ((float)nFonts*nHeight)/(float)texH;
+	float y_offset = ((float)nFonts*MAX_CHARSETS*nHeight)/(float)texH;
 	float x1 = ((float)1)/(float)texW;
 	float y1 = ((float)1)/(float)texH;
 	GLfloat texCopy[] = {
@@ -278,9 +291,13 @@ void SDLFontGL::drawBackground(int color, int nX, int nY, int cells) {
 	}
 }
 
-void SDLFontGL::drawTextGL(int fnt, int fg, int bg,
+void SDLFontGL::drawTextGL(TextGraphicsInfo_t & graphicsInfo,
 													 int nX, int nY, const char * text) {
 	if (!GlyphCache) createTexture();
+
+	int fnt = graphicsInfo.font;
+	int fg = graphicsInfo.fg;
+	int bg = graphicsInfo.bg;
 
 	assert(fnt >= 0 && fnt < nFonts);
 	assert(fg >= 0 && fg < nCols);
@@ -289,8 +306,9 @@ void SDLFontGL::drawTextGL(int fnt, int fg, int bg,
 
 	unsigned len = strlen(text);
 
-	// Ensure we have this font line:
-	ensureFontLine(fnt);
+	// Ensure we have the needed font/slots:
+	ensureCacheLine(fnt, graphicsInfo.slot1);
+	ensureCacheLine(fnt, graphicsInfo.slot2);
 
 	const int stride = 12; // GL_TRIANGLE_STRIP 2*6
 
@@ -347,7 +365,6 @@ void SDLFontGL::drawTextGL(int fnt, int fg, int bg,
 			1.f
 	};
 
-	float y_offset = ((float)(fnt*nHeight)) / (float)texH;
 	for (unsigned i = 0; i < len; ++i)
 	{
 		// Populate texture coordinates
@@ -355,8 +372,11 @@ void SDLFontGL::drawTextGL(int fnt, int fg, int bg,
 
 		char c = text[i];
 
-		int index = c > 127 ? c - 33 : c - 32;
-		float x_offset = ((float)(index * nWidth)) / texW;
+		int x,y;
+		getTextureCoordinates(graphicsInfo, c, x, y);
+
+		float x_offset = ((float)x) / texW;
+		float y_offset = ((float)y) / texH;
 
 		for(unsigned j = 0; j < stride; j += 2) {
 			tex[i*stride+j] += x_offset;
@@ -414,13 +434,25 @@ void SDLFontGL::endTextGL() {
 	glDisableClientState(GL_COLOR_ARRAY);
 }
 
-void SDLFontGL::initializePrintables() {
-	nChars = 223;
-	assert(sizeof(printableChars)/sizeof(printableChars[0]) >= 223);
+void SDLFontGL::setCharMapping(int index, CharMapping_t map) {
+	assert(index >= 0 && index < MAX_CHARSETS);
+	memcpy(&charMappings[index], &map, sizeof(CharMapping_t));
 
-	// Characters [32,127),[128,255]
-	for(unsigned i = 32; i < 127; ++i)
-		printableChars[i-32] = i;
-	for(unsigned i = 128; i < 256; ++i)
-		printableChars[i-33] = i;
+	// Invalidate the appropriate cache lines
+	for(unsigned i = 0; i < nFonts; ++i)
+		hasCacheLine(i, index) = false;
+}
+
+void SDLFontGL::getTextureCoordinates(TextGraphicsInfo_t & graphicsInfo, char c, int &x, int &y) {
+	int slot = c > 127 ? graphicsInfo.slot1 : graphicsInfo.slot2;
+
+	assert(hasCacheLine(graphicsInfo.font, slot));
+
+	// Set by reference
+	x = (c % 128)*nWidth;
+	y = (slot*nFonts + graphicsInfo.font)*nHeight;
+}
+
+bool &SDLFontGL::hasCacheLine(int font, int slot) {
+	return haveCacheLine[slot*nFonts + font];
 }

--- a/src/plugin/sdl/sdlfontgl.h
+++ b/src/plugin/sdl/sdlfontgl.h
@@ -23,7 +23,7 @@
 #include <SDL/SDL.h>
 #include <SDL/SDL_ttf.h>
 
-#define MAX_CHARSETS 10
+#define MAX_CHARSETS 12
 
 // OpenGL Font Rendering
 class SDLFontGL {

--- a/src/plugin/sdl/sdlfontgl.h
+++ b/src/plugin/sdl/sdlfontgl.h
@@ -23,15 +23,28 @@
 #include <SDL/SDL.h>
 #include <SDL/SDL_ttf.h>
 
+#define MAX_CHARSETS 10
+
 // OpenGL Font Rendering
 class SDLFontGL {
+public:
+	typedef struct {
+		Uint16 map[128];
+	} CharMapping_t;
+	typedef struct {
+		int font;
+		int fg;
+		int bg;
+		int slot1;
+		int slot2;
+	} TextGraphicsInfo_t;
 private:
 	// Master font rendering texture.
 	GLuint GlyphCache;
 	int texW, texH;
 
-	// Dirty bit for each font
-	bool * haveFontLine;
+	// Dirty bit for each cache line
+	bool * haveCacheLine;
 
 	int nFonts, nCols;
 	TTF_Font** fnts;
@@ -43,21 +56,24 @@ private:
 	GLfloat * texValues;
 	GLfloat * vtxValues;
 	int numChars;
-	char printableChars[223];
-	size_t nChars;
+
+	// Encodings
+	CharMapping_t charMappings[MAX_CHARSETS];
 
 	void clearGL();
-	void ensureFontLine(int font);
+	void ensureCacheLine(int font, int slot);
+	bool &hasCacheLine(int font, int slot);
 	void createTexture();
 	void drawBackground(int color, int X, int Y, int cells);
-
-	void initializePrintables();
+	Uint16 lookupChar(char c);
+	void initializeCharMapping();
+	void getTextureCoordinates(TextGraphicsInfo_t & graphicsInfo, char c, int &x, int &y);
 
 public:
-	SDLFontGL() : GlyphCache(0), texW(0), texH(0), haveFontLine(0),
+	SDLFontGL() : GlyphCache(0), texW(0), texH(0), haveCacheLine(0),
 	nFonts(0), nCols(0), fnts(0), cols(0), screenCols(0), screenRows(0),
 	colorValues(0), texValues(0), vtxValues(0) {
-		initializePrintables();
+		memset(charMappings,0, sizeof(charMappings));
 	}
 	~SDLFontGL();
 
@@ -65,9 +81,12 @@ public:
 	// This invalidates the cache, so only call when things change.
 	void setupFontGL(int fnCount, TTF_Font** fnts, int colCount, SDL_Color *cols);
 
+	// Define a character set
+	void setCharMapping(int index, CharMapping_t map);
+
 	// Begin drawing text to the screen, assuming the given screen size
 	void startTextGL(int cols, int rows);
-	void drawTextGL(int font, int fg, int bg, int x, int y, const char * text);
+	void drawTextGL(TextGraphicsInfo_t & graphicsInfo, int x, int y, const char * text);
 	// Done drawing text, commit!
 	void endTextGL();
 };

--- a/src/plugin/sdl/sdlterminal.cpp
+++ b/src/plugin/sdl/sdlterminal.cpp
@@ -727,4 +727,7 @@ void SDLTerminal::setGraphicsState(TSLineGraphicsState_t &state)
 
 	m_bBold = ((state.nGraphicsMode & TS_GM_BOLD) > 0);
 	m_bUnderline = ((state.nGraphicsMode & TS_GM_UNDERSCORE) > 0);
+
+	m_slot1 = state.g0charset;
+	m_slot2 = state.g1charset;
 }

--- a/src/plugin/terminal/terminalstate.cpp
+++ b/src/plugin/terminal/terminalstate.cpp
@@ -32,7 +32,9 @@ int cmp_graphics_state(TSLineGraphicsState_t const *state1, TSLineGraphicsState_
 	{
 		if (state1->nGraphicsMode == state2->nGraphicsMode
 			&& state1->foregroundColor == state2->foregroundColor
-			&& state1->backgroundColor == state2->backgroundColor)
+			&& state1->backgroundColor == state2->backgroundColor
+			&& state1->g0charset == state2->g0charset
+			&& state1->g1charset == state2->g1charset)
 		{
 			return 0;
 		}
@@ -1500,6 +1502,10 @@ void TerminalState::addGraphicsState(int nColumn, int nLine, TSColor_t foregroun
 	newState->foregroundColor = foregroundColor;
 	newState->backgroundColor = backgroundColor;
 	newState->nGraphicsMode = nMode;
+
+	// TODO: Implement this properly!
+	newState->g0charset = m_defaultGraphicsState.g0charset;
+	newState->g1charset = m_defaultGraphicsState.g1charset;
 
 	if (prevState != newState)
 	{


### PR DESCRIPTION
Add sdlfontgl support for the two character mapping slots, and stub out most of the supporting infrastructure.

Things TODO:
- Somewhere actually define the mappings, see SDLFontGL::setCharMapping(...)
- Logic to set the charsets on graphics states appropriately.
