### PR TITLE
Fix cursor rendering.

### DIFF
--- a/src/plugin/sdl/sdlterminal.cpp
+++ b/src/plugin/sdl/sdlterminal.cpp
@@ -474,9 +474,6 @@ void SDLTerminal::redraw()
 	setGraphicsState(defState);
 	clearScreen();
 
-	startTextGL(m_terminalState->getDisplayScreenSize().getX() + 1,
-							m_terminalState->getDisplayScreenSize().getY() + 1);
-
 	if (size <= 0)
 	{
 		nResult = -1;
@@ -501,6 +498,10 @@ void SDLTerminal::redraw()
 
 	if (nResult == 0)
 	{
+
+		startTextGL(m_terminalState->getDisplayScreenSize().getX() + 1,
+				m_terminalState->getDisplayScreenSize().getY() + 1);
+
 		for (int i = nTopLineIndex; i < nEndLine; i++)
 		{
 			m_terminalState->getLineGraphicsState(nLine, states, nNumStates, nMaxStates);
@@ -568,6 +569,8 @@ void SDLTerminal::redraw()
 			nLine++;
 		}
 
+		endTextGL();
+
 		if (m_terminalState->getTerminalModeFlags() & TS_TM_CURSOR)
 			drawCursor(m_terminalState->getCursorLocation().getX(), m_terminalState->getCursorLocation().getY());
 	}
@@ -581,8 +584,6 @@ void SDLTerminal::redraw()
 	{
 		free(states);
 	}
-
-	endTextGL();
 
 	m_terminalState->unlock();
 


### PR DESCRIPTION
Accidentally put startTextGL/endTextGL around the cursor drawing code,
    resulting in a bad client state.

Fixes #32.
