### PR TITLE
Finish hooking up charsets to their graphicstate, misc fixes.

### DIFF
--- a/src/plugin/sdl/sdlfontgl.cpp
+++ b/src/plugin/sdl/sdlfontgl.cpp
@@ -145,8 +145,6 @@ void SDLFontGL::clearGL() {
 		GlyphCache = 0;
 	}
 
-	memset(charMappings, 0, sizeof(charMappings));
-
 	free(haveCacheLine);
 	free(fnts);
 	free(cols);

--- a/src/plugin/terminal/terminalstate.hpp
+++ b/src/plugin/terminal/terminalstate.hpp
@@ -130,7 +130,8 @@ typedef enum
 
 typedef enum
 {
-	TS_CS_G0_UK = 0,
+	TS_CS_NONE = 0,
+	TS_CS_G0_UK,
 	TS_CS_G0_ASCII,
 	TS_CS_G0_SPEC,
 	TS_CS_G0_ALT_STD,
@@ -294,7 +295,8 @@ public:
 	void unlock();
 
 	void getLineGraphicsState(int nLine, TSLineGraphicsState_t **states, int &nNumStates, int nMaxStates);
-	void addGraphicsState(int nColumn, int nLine, TSColor_t foregroundColor, TSColor_t backgroundColor, int nGraphicsMode, TSGraphicsModeOp_t op, bool bTrim, TSCharset_t g0charset, TSCharset_t g1charset);
+	void addGraphicsState(int nColumn, int nLine, TSLineGraphicsState_t& state, TSGraphicsModeOp_t op, bool bTrim);
+	void addGraphicsState(int nColumn, int nLine, TSColor_t foregroundColor, TSColor_t backgroundColor, int nGraphicsMode, TSCharset_t g0charset, TSCharset_t g1charset, TSGraphicsModeOp_t op, bool bTrim);
 
 	void resetTerminal();
 	void insertLines(int nLines);


### PR DESCRIPTION
- Don't reset the charMappings in SDLFontGL::clearGL, assume they're the same.
- Apply shift to all printables and unhandled non-printables.
- Simplify overly verbose addGraphicsState invocations
- Use cmp_graphics_state in more places where it makes sense.
- Restore TS_CS_NONE for use as a placeholder.
