### PR TITLE
Fix bluetooth keyboard input focus issues

### DIFF
--- a/src/enyo/main.js
+++ b/src/enyo/main.js
@@ -14,7 +14,7 @@ enyo.kind({
 			{name: 'vkbToggle', caption: "Hide Virtual Keyboard", onclick: 'toggleVKB'},
 			{caption: "Preferences", onclick: "openPrefs"}
 		]},
-		{kind: "ApplicationEvents", onWindowRotated: "setup"},
+		{kind: "ApplicationEvents", onWindowRotated: "setup", onKeydown: "onBtKeyDown"},
 		{
 			kind: 'Popup2',
 			name: 'about',
@@ -131,6 +131,14 @@ enyo.kind({
 				this.$.terminal.resize(window.innerWidth, 722)
 			else
 				this.$.terminal.resize(window.innerWidth, window.innerHeight)
+		}
+	},
+
+	onBtKeyDown: function(context, event) {
+		if (this.$.terminal.$.plugin.hasNode())
+		{
+			this.$.terminal.$.plugin.node.focus();
+			this.$.terminal.$.plugin.node.dispatchEvent(event);
 		}
 	}
 

--- a/src/enyo/plugin.js
+++ b/src/enyo/plugin.js
@@ -25,6 +25,7 @@ enyo.kind({
 			onPluginReady: 'pluginReady',
 			onPluginConnected: 'pluginConnected',
 			onPluginDisconnected: 'pluginDisconnected',
+			allowKeyboardFocus: true,
 			width: this.width,
 			height: this.height,
 			params: [this.prefs.get('fontSize').toString(10)]


### PR DESCRIPTION
Capture keyDown event, set focus to terminal object, and redirect the key event to the terminal object.
This should only happen when the terminal object doesn't have focus and thus fire rarely.
