### PR TITLE
Simplify and cleanup control-modifier handling code, fix support for missing ones

### DIFF
--- a/src/plugin/sdl/sdlterminal.cpp
+++ b/src/plugin/sdl/sdlterminal.cpp
@@ -308,21 +308,13 @@ void SDLTerminal::handleKeyboardEvent(SDL_Event &event)
 			c[0] = unicode & 0x7F;
 
 			if (mod & KMOD_CTRL) {
-				if (c[0] > 96 && c[0] < 123) {
-					c[0] -= 96;
-				} else switch (c[0]) {
-					case 32:
-					case 64:
-						c[0] = 0;
-						break;
-					case 91:
-					case 92:
-					case 93:
-					case 94:
-					case 95:
-						c[0] -= 34;
-						break;
-				}
+        // SDL gives us capitalized alpha, make them lowercase
+        if (c[0] >= 'A' && c[0] <= 'Z') {
+          c[0] -= 'A' - 'a';
+        }
+
+        // Encode control by masking
+        c[0] &= 0x1f;
 			} else if (mod & KMOD_ALT) {
 					c[1] = c[0];
 					c[0] = '\x1b';


### PR DESCRIPTION
(control-\ didn't work, for example, possibly others)

See http://www.leonerd.org.uk/hacks/fixterms/ for the 0x1f bit.  Everything works here except for characters munged by webOS (escape, control-a, etc).

Down the road it might make sense to encode it using the proposed encoding these since a)it's unambiguous and b)comparatively easy to implement.  I don't know that there's any priority to do so until something breaks however (or we want to be able to generate utf8 input chars).
