### PR TITLE
Small changes for building on-device.

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,6 +1,14 @@
 
 BUILD_ROOT=/srv/preware/build
 
+ifdef NATIVE
+
+CC=gcc
+CXX=g++
+ROOT=/media/ext3fs/dev
+MARCH_TUNE=-O2 -march=armv7-a -mcpu=cortex-a8 -mfpu=neon -mfloat-abi=softfp
+
+else
 ifdef DEVICE
 	ARCH=armv7
 	HOST=arm-none-linux-gnueabi
@@ -27,6 +35,7 @@ else
 		CXX=$(BUILD_ROOT)/toolchain/i686-unknown-linux-gnu/build/i686-unknown-linux-gnu/bin/i686-unknown-linux-gnu-g++
 		ROOT=$(BUILD_ROOT)/staging/i686/usr
 	endif
+endif
 endif
 
 ifeq ($(DEBUG),1)


### PR DESCRIPTION
Assumes you have misc build stuff from optware installed, and that you've put your includes and such into /media/ext3fs/dev (/media/ext3fs/dev/include).
