### PR TITLE
Small fix to set the background color of empty cells.

### DIFF
--- a/src/plugin/sdl/sdlfontgl.cpp
+++ b/src/plugin/sdl/sdlfontgl.cpp
@@ -706,5 +706,12 @@ void SDLFontGL::drawTextGL(TextGraphicsInfo_t & graphicsInfo, unsigned int col, 
 void SDLFontGL::clearText() {
 	if (m_cellData) {
 		memset(m_cellData, 0, 4*m_cellsWidth * m_cellsHeight);
+		// Set default background, used for unspecified cells.
+		for(unsigned row = 0; row < m_rows; ++row) {
+			for(unsigned col = 0; col < m_cols; ++col) {
+				unsigned int ndx = 4*(col + m_cellsWidth*(m_rows - row - 1));
+				m_cellData[ndx+3] = TS_COLOR_BACKGROUND;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Previously it would fall back to '0' (black) in all cases, ignoring theme.

To see this in action, try a theme such as 'dark pastels' and then run vttest, menu 2.  During the scroll tests we see it showing black background for empty cells instead of the correct theme background.  This commit fixes that by pre-setting the background color to be, well, the theme's background color.

The shader should probably know what characters are unset, since while this commit fixes this issue, in general it seems that the fact that an empty cell renders correctly is more luck than anything else (which is why this was wrong).  On that, can '0' be a valid character index?  If not, we could update the shader to check that and render accordingly.

Anyway, this works for now.
